### PR TITLE
Normalise paths, align S3 data, python client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ strum_macros = "0.24"
 thiserror = "1.0"
 tokio = { version = "1.24", features = ["full"] }
 tower = "0.4"
-tower-http = { version = "0.3", features = ["trace", "validate-request"] }
+tower-http = { version = "0.3", features = ["normalize-path", "trace", "validate-request"] }
 url = { version = "2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,8 @@
 name = "s3-active-storage"
 version = "0.1.0"
 edition = "2021"
+# Due to AWS SDK.
+rust-version = "1.62.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ aws-sdk-s3 = "0.24"
 aws-types = "0.54"
 axum = { version = "0.6", features = ["headers"] }
 hyper = { version = "0.14", features = ["full"] }
+maligned = "0.2.1"
 mime = "0.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "*"

--- a/scripts/client.py
+++ b/scripts/client.py
@@ -1,0 +1,30 @@
+# Make a request to the active storage server.
+
+import json
+import requests
+import numpy as np
+import sys
+
+request_data = {
+  'source': 'http://localhost:9000',
+  'bucket': 'sample-data',
+  'object': 'data-uint32.dat',
+  'dtype': 'uint32',
+  # All other fields assume their default values
+}
+
+if len(sys.argv) > 1:
+    reducer = sys.argv[1]
+else:
+    reducer = 'min'
+
+response = requests.post(
+  f'http://localhost:8080/v1/{reducer}',
+  json=request_data,
+  auth=('minioadmin', 'minioadmin')
+)
+print(response.content)
+sum_result = np.frombuffer(response.content, dtype=response.headers['x-activestorage-dtype'])
+shape = json.loads(response.headers['x-activestorage-shape'])
+sum_result = sum_result.reshape(shape)
+print(sum_result)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,3 @@
-aioboto3
-botocore
 numpy
+requests
 s3fs

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,6 +14,7 @@ use axum::{
 };
 
 use tower::ServiceBuilder;
+use tower_http::normalize_path::NormalizePathLayer;
 use tower_http::trace::TraceLayer;
 use tower_http::validate_request::ValidateRequestHeaderLayer;
 
@@ -65,6 +66,7 @@ pub fn router() -> Router {
     Router::new()
         .route("/.well-known/s3-active-storage-schema", get(schema))
         .nest("/v1", v1())
+        .layer(NormalizePathLayer::trim_trailing_slash())
 }
 
 async fn schema() -> &'static str {


### PR DESCRIPTION
- Explicitly set MSRV in Cargo.toml
- api: Normalise paths to remove trailing slashes
- s3_client: Return data in an 8-byte aligned slice
- Add basic Python client for testing
