### PR TITLE
ndarray

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ rust-version = "1.62.1"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+anyhow = "1.0"
 async-trait = "0.1"
 aws-config = "0.54"
 aws-credential-types = { version = "0.54", features = ["hardcoded-credentials"] }
@@ -17,6 +18,7 @@ axum = { version = "0.6", features = ["headers"] }
 hyper = { version = "0.14", features = ["full"] }
 maligned = "0.2.1"
 mime = "0.3"
+ndarray = "0.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "*"
 strum = { version = "0.24", features = ["derive"] }
@@ -27,6 +29,7 @@ tower = "0.4"
 tower-http = { version = "0.3", features = ["normalize-path", "trace", "validate-request"] }
 url = { version = "2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
+zerocopy = { version = "0.6.1", features = ["alloc", "simd"] }
 
 [dev-dependencies]
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ hyper = { version = "0.14", features = ["full"] }
 maligned = "0.2.1"
 mime = "0.3"
 ndarray = "0.15"
+num-traits = "0.2.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "*"
 strum = { version = "0.24", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ hyper = { version = "0.14", features = ["full"] }
 maligned = "0.2.1"
 mime = "0.3"
 ndarray = "0.15"
+ndarray-stats = "0.5"
 num-traits = "0.2.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "*"

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,7 +32,7 @@ impl IntoResponse for models::Response {
                 (&HEADER_DTYPE, self.dtype.to_string().to_lowercase()),
                 (&HEADER_SHAPE, serde_json::to_string(&self.shape).unwrap()),
             ],
-            self.result,
+            self.body,
         )
             .into_response()
     }
@@ -82,7 +82,7 @@ async fn count(
         .download_object(&request_data.bucket, &request_data.object, None)
         .await;
     let message = format!("{:?}", data);
-    models::Response::new(message, models::DType::Int32, vec![])
+    models::Response::new(message.into(), models::DType::Int32, vec![])
 }
 
 async fn max(
@@ -95,7 +95,7 @@ async fn max(
         auth.username(),
         auth.password()
     );
-    models::Response::new(message, models::DType::Int32, vec![])
+    models::Response::new(message.into(), models::DType::Int32, vec![])
 }
 
 async fn mean(
@@ -108,7 +108,7 @@ async fn mean(
         auth.username(),
         auth.password()
     );
-    models::Response::new(message, models::DType::Int32, vec![])
+    models::Response::new(message.into(), models::DType::Int32, vec![])
 }
 
 async fn min(
@@ -121,7 +121,7 @@ async fn min(
         auth.username(),
         auth.password()
     );
-    models::Response::new(message, models::DType::Int32, vec![])
+    models::Response::new(message.into(), models::DType::Int32, vec![])
 }
 
 async fn select(
@@ -134,7 +134,7 @@ async fn select(
         auth.username(),
         auth.password()
     );
-    models::Response::new(message, models::DType::Int32, vec![])
+    models::Response::new(message.into(), models::DType::Int32, vec![])
 }
 
 async fn sum(
@@ -147,5 +147,5 @@ async fn sum(
         auth.username(),
         auth.password()
     );
-    models::Response::new(message, models::DType::Int32, vec![])
+    models::Response::new(message.into(), models::DType::Int32, vec![])
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,9 +1,11 @@
 use crate::models;
-use crate::s3_client::S3Client;
+use crate::operation;
+use crate::operations;
+use crate::s3_client;
 use crate::validated_json::ValidatedJson;
 
 use axum::{
-    body::Body,
+    body::{Body, Bytes},
     headers::authorization::{Authorization, Basic},
     http::header,
     http::Request,
@@ -41,12 +43,12 @@ impl IntoResponse for models::Response {
 pub fn router() -> Router {
     fn v1() -> Router {
         Router::new()
-            .route("/count", post(count))
-            .route("/max", post(max))
-            .route("/mean", post(mean))
-            .route("/min", post(min))
-            .route("/select", post(select))
-            .route("/sum", post(sum))
+            .route("/count", post(operation_handler::<operations::Count>))
+            .route("/max", post(operation_handler::<operations::Max>))
+            .route("/mean", post(operation_handler::<operations::Mean>))
+            .route("/min", post(operation_handler::<operations::Min>))
+            .route("/select", post(operation_handler::<operations::Select>))
+            .route("/sum", post(operation_handler::<operations::Sum>))
             .layer(
                 ServiceBuilder::new()
                     .layer(TraceLayer::new_for_http())
@@ -73,79 +75,26 @@ async fn schema() -> &'static str {
     "Hello, world!"
 }
 
-async fn count(
-    TypedHeader(auth): TypedHeader<Authorization<Basic>>,
-    ValidatedJson(request_data): ValidatedJson<models::RequestData>,
-) -> models::Response {
-    let client = S3Client::new(&request_data.source, auth.username(), auth.password()).await;
-    let data = client
-        .download_object(&request_data.bucket, &request_data.object, None)
-        .await;
-    let message = format!("{:?}", data);
-    models::Response::new(message.into(), models::DType::Int32, vec![])
+async fn download_object(auth: &Authorization<Basic>, request_data: &models::RequestData) -> Bytes {
+    let range = s3_client::get_range(request_data.offset, request_data.size);
+    s3_client::S3Client::new(&request_data.source, auth.username(), auth.password())
+        .await
+        .download_object(&request_data.bucket, &request_data.object, range)
+        .await
 }
 
-async fn max(
+/// Handler for operations
+///
+/// Returns a `Result` with `models::Response` on success and `AppError` on failure.
+///
+/// # Arguments
+///
+/// * `auth`: Basic authorization header
+/// * `request_data`: RequestData object for the request
+async fn operation_handler<T: operation::Operation>(
     TypedHeader(auth): TypedHeader<Authorization<Basic>>,
     ValidatedJson(request_data): ValidatedJson<models::RequestData>,
 ) -> models::Response {
-    let message = format!(
-        "url {} username {} password {}",
-        request_data.source,
-        auth.username(),
-        auth.password()
-    );
-    models::Response::new(message.into(), models::DType::Int32, vec![])
-}
-
-async fn mean(
-    TypedHeader(auth): TypedHeader<Authorization<Basic>>,
-    ValidatedJson(request_data): ValidatedJson<models::RequestData>,
-) -> models::Response {
-    let message = format!(
-        "url {} username {} password {}",
-        request_data.source,
-        auth.username(),
-        auth.password()
-    );
-    models::Response::new(message.into(), models::DType::Int32, vec![])
-}
-
-async fn min(
-    TypedHeader(auth): TypedHeader<Authorization<Basic>>,
-    ValidatedJson(request_data): ValidatedJson<models::RequestData>,
-) -> models::Response {
-    let message = format!(
-        "url {} username {} password {}",
-        request_data.source,
-        auth.username(),
-        auth.password()
-    );
-    models::Response::new(message.into(), models::DType::Int32, vec![])
-}
-
-async fn select(
-    TypedHeader(auth): TypedHeader<Authorization<Basic>>,
-    ValidatedJson(request_data): ValidatedJson<models::RequestData>,
-) -> models::Response {
-    let message = format!(
-        "url {} username {} password {}",
-        request_data.source,
-        auth.username(),
-        auth.password()
-    );
-    models::Response::new(message.into(), models::DType::Int32, vec![])
-}
-
-async fn sum(
-    TypedHeader(auth): TypedHeader<Authorization<Basic>>,
-    ValidatedJson(request_data): ValidatedJson<models::RequestData>,
-) -> models::Response {
-    let message = format!(
-        "url {} username {} password {}",
-        request_data.source,
-        auth.username(),
-        auth.password()
-    );
-    models::Response::new(message.into(), models::DType::Int32, vec![])
+    let data = download_object(&auth, &request_data).await;
+    T::execute(&request_data, &data)
 }

--- a/src/array.rs
+++ b/src/array.rs
@@ -14,7 +14,6 @@ use ndarray::prelude::*;
 /// # Arguments
 ///
 /// * `data`: Bytes containing data to convert.
-#[allow(dead_code)]
 fn from_bytes<T: zerocopy::FromBytes>(data: &Bytes) -> anyhow::Result<&[T]> {
     let layout = zerocopy::LayoutVerified::<_, [T]>::new_slice(&data[..]).ok_or(anyhow!(
         "Failed to convert from bytes to {}",
@@ -29,7 +28,6 @@ fn from_bytes<T: zerocopy::FromBytes>(data: &Bytes) -> anyhow::Result<&[T]> {
 ///
 /// * `size`: Number of elements in the array
 /// * `request_data`: RequestData object for the request
-#[allow(dead_code)]
 fn get_shape(
     size: usize,
     request_data: &models::RequestData,
@@ -52,7 +50,6 @@ fn get_shape(
 ///
 /// * `shape`: The shape of the array
 /// * `data`: A slice of type `&[T]` containing the data to be consumed by the array view.
-#[allow(dead_code)]
 fn build_array_from_shape<T>(
     shape: ndarray::Shape<Dim<ndarray::IxDynImpl>>,
     data: &[T],
@@ -61,7 +58,6 @@ fn build_array_from_shape<T>(
 }
 
 /// Returns an optional [ndarray] SliceInfo object corresponding to the selection.
-#[allow(dead_code)]
 pub fn build_slice_info<T>(
     selection: &Option<Vec<models::Slice>>,
     shape: &[usize],
@@ -104,7 +100,6 @@ pub fn build_slice_info<T>(
 /// * `data`: Bytes containing data for the array. Must be at least as aligned as an instance of
 ///   `T`.
 /// * `request_data`: RequestData object for the request
-#[allow(dead_code)]
 pub fn build_array<'a, T>(
     request_data: &'a models::RequestData,
     data: &'a Bytes,

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,0 +1,408 @@
+//! This module provides functions and utilities for working with ndarray objects.
+
+use crate::models;
+
+use anyhow::anyhow;
+use axum::body::Bytes;
+use ndarray::prelude::*;
+
+/// Convert from Bytes to `&[T]`.
+///
+/// Zerocopy provides a mechanism for converting between types.
+/// Correct alignment of the data is necessary.
+///
+/// # Arguments
+///
+/// * `data`: Bytes containing data to convert.
+#[allow(dead_code)]
+fn from_bytes<T: zerocopy::FromBytes>(data: &Bytes) -> anyhow::Result<&[T]> {
+    let layout = zerocopy::LayoutVerified::<_, [T]>::new_slice(&data[..]).ok_or(anyhow!(
+        "Failed to convert from bytes to {}",
+        std::any::type_name::<T>()
+    ))?;
+    Ok(layout.into_slice())
+}
+
+/// Returns an [ndarray] Shape corresponding to the data in the request.
+///
+/// # Arguments
+///
+/// * `size`: Number of elements in the array
+/// * `request_data`: RequestData object for the request
+#[allow(dead_code)]
+fn get_shape(
+    size: usize,
+    request_data: &models::RequestData,
+) -> ndarray::Shape<Dim<ndarray::IxDynImpl>> {
+    // Use the provided shape, or fall back to a 1D array.
+    let shape = request_data.shape.clone().unwrap_or(vec![size]);
+    // Convert the Vec into a Shape.
+    let shape = shape.into_shape();
+    match request_data.order {
+        Some(models::Order::F) => shape.f(),
+        _ => shape,
+    }
+}
+
+/// Returns an [ndarray::ArrayView](ndarray::ArrayView) corresponding to the data in the request.
+///
+/// The array view borrows the data, so no copying takes place.
+///
+/// # Arguments
+///
+/// * `shape`: The shape of the array
+/// * `data`: A slice of type `&[T]` containing the data to be consumed by the array view.
+#[allow(dead_code)]
+fn build_array_from_shape<T>(
+    shape: ndarray::Shape<Dim<ndarray::IxDynImpl>>,
+    data: &[T],
+) -> Result<ArrayView<T, ndarray::Dim<ndarray::IxDynImpl>>, ndarray::ShapeError> {
+    ArrayView::<T, _>::from_shape(shape, data)
+}
+
+/// Returns an optional [ndarray] SliceInfo object corresponding to the selection.
+#[allow(dead_code)]
+pub fn build_slice_info<T>(
+    selection: &Option<Vec<models::Slice>>,
+    shape: &[usize],
+) -> Option<ndarray::SliceInfo<Vec<ndarray::SliceInfoElem>, ndarray::IxDyn, ndarray::IxDyn>> {
+    match selection {
+        Some(selection) => {
+            let si = selection
+                .iter()
+                .map(|slice| ndarray::SliceInfoElem::Slice {
+                    // FIXME: usize should be isize?
+                    start: slice.start as isize,
+                    end: Some(slice.end as isize),
+                    step: slice.stride as isize,
+                })
+                .collect();
+            unsafe { Some(ndarray::SliceInfo::new(si).unwrap()) }
+        }
+        _ => {
+            //let si = (1..shape.len()).map(|index| ndarray::SliceInfoElem::Index(index as isize)).collect();
+            let si = shape
+                .iter()
+                .map(|_| ndarray::SliceInfoElem::Slice {
+                    // FIXME: usize should be isize?
+                    start: 0,
+                    end: None,
+                    step: 1,
+                })
+                .collect();
+            unsafe { Some(ndarray::SliceInfo::new(si).unwrap()) }
+        }
+    }
+}
+
+/// Build an [ndarray::ArrayView](ndarray::ArrayView) object corresponding to the request and data Bytes.
+///
+/// The resulting array will contain a reference to `data`.
+///
+/// # Arguments
+///
+/// * `data`: Bytes containing data for the array. Must be at least as aligned as an instance of
+///   `T`.
+/// * `request_data`: RequestData object for the request
+#[allow(dead_code)]
+pub fn build_array<'a, T>(
+    request_data: &'a models::RequestData,
+    data: &'a Bytes,
+) -> ArrayView<'a, T, ndarray::Dim<ndarray::IxDynImpl>>
+where
+    T: zerocopy::FromBytes,
+{
+    let data = from_bytes::<T>(data).unwrap();
+    let shape = get_shape(data.len(), request_data);
+    build_array_from_shape(shape, data).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use url::Url;
+
+    #[test]
+    fn from_bytes_u32() {
+        assert_eq!(
+            [0x04030201_u32],
+            from_bytes::<u32>(&Bytes::from_static(&[1, 2, 3, 4])).unwrap()
+        );
+    }
+
+    #[test]
+    fn from_bytes_u64() {
+        assert_eq!(
+            [0x0807060504030201_u64],
+            from_bytes::<u64>(&Bytes::from_static(&[1, 2, 3, 4, 5, 6, 7, 8])).unwrap()
+        );
+    }
+
+    #[test]
+    fn from_bytes_i32() {
+        assert_eq!(
+            [0x04030201_i32],
+            from_bytes::<i32>(&Bytes::from_static(&[1, 2, 3, 4])).unwrap()
+        );
+    }
+
+    #[test]
+    fn from_bytes_i64() {
+        assert_eq!(
+            [0x0807060504030201_i64],
+            from_bytes::<i64>(&Bytes::from_static(&[1, 2, 3, 4, 5, 6, 7, 8])).unwrap()
+        );
+    }
+
+    #[test]
+    fn from_bytes_f32() {
+        assert_eq!(
+            [1.5399896e-36_f32],
+            from_bytes::<f32>(&Bytes::from_static(&[1, 2, 3, 4])).unwrap()
+        );
+    }
+
+    #[test]
+    fn from_bytes_f64() {
+        assert_eq!(
+            [5.447603722011605e-270_f64],
+            from_bytes::<f64>(&Bytes::from_static(&[1, 2, 3, 4, 5, 6, 7, 8])).unwrap()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Failed to convert from bytes to u32")]
+    fn from_bytes_u32_too_small() {
+        from_bytes::<u32>(&Bytes::from_static(&[1, 2, 3])).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Failed to convert from bytes to u32")]
+    fn from_bytes_u32_too_big() {
+        from_bytes::<u32>(&Bytes::from_static(&[1, 2, 3, 4, 5])).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Failed to convert from bytes to u32")]
+    fn from_bytes_u32_unaligned() {
+        static ARRAY: [u8; 5] = [1, 2, 3, 4, 5];
+        from_bytes::<u32>(&Bytes::from_static(&ARRAY[1..])).unwrap();
+    }
+
+    #[test]
+    fn get_shape_without_shape() {
+        let shape = get_shape(
+            42,
+            &models::RequestData {
+                source: Url::parse("http://example.com").unwrap(),
+                bucket: "bar".to_string(),
+                object: "baz".to_string(),
+                dtype: models::DType::Int32,
+                offset: None,
+                size: None,
+                shape: None,
+                order: None,
+                selection: None,
+            },
+        );
+        assert_eq!([42], shape.raw_dim().as_array_view().as_slice().unwrap());
+    }
+
+    #[test]
+    fn get_shape_with_shape() {
+        let shape = get_shape(
+            42,
+            &models::RequestData {
+                source: Url::parse("http://example.com").unwrap(),
+                bucket: "bar".to_string(),
+                object: "baz".to_string(),
+                dtype: models::DType::Int32,
+                offset: None,
+                size: None,
+                shape: Some(vec![1, 2, 3]),
+                order: None,
+                selection: None,
+            },
+        );
+        assert_eq!(
+            [1, 2, 3],
+            shape.raw_dim().as_array_view().as_slice().unwrap()
+        );
+    }
+
+    #[test]
+    fn build_array_from_shape_1d() {
+        let data = [1, 2, 3];
+        let shape = vec![3].into_shape();
+        let array = build_array_from_shape(shape, &data).unwrap();
+        assert_eq!(array![1, 2, 3].into_dyn(), array);
+    }
+
+    #[test]
+    fn build_array_from_shape_1d_fortran() {
+        let data = [1, 2, 3];
+        let shape = vec![3].into_shape().f();
+        let array = build_array_from_shape(shape, &data).unwrap();
+        assert_eq!(array![1, 2, 3].into_dyn(), array);
+    }
+
+    #[test]
+    fn build_array_from_shape_2d() {
+        let data = [1.0, 2.1, 3.2, 4.3, 5.4, 6.5];
+        let shape = vec![2, 3].into_shape();
+        let array = build_array_from_shape(shape, &data).unwrap();
+        assert_eq!(array![[1.0, 2.1, 3.2], [4.3, 5.4, 6.5]].into_dyn(), array);
+    }
+
+    #[test]
+    fn build_array_from_shape_2d_fortran() {
+        let data = [1.0, 2.1, 3.2, 4.3, 5.4, 6.5];
+        let shape = vec![2, 3].into_shape().f();
+        let array = build_array_from_shape(shape, &data).unwrap();
+        assert_eq!(array![[1.0, 3.2, 5.4], [2.1, 4.3, 6.5]].into_dyn(), array);
+    }
+
+    #[test]
+    fn build_array_from_shape_3d() {
+        let data = [1, 2, 3, 4, 5, 6, 7, 8];
+        let shape = vec![2, 2, 2].into_shape();
+        let array = build_array_from_shape(shape, &data).unwrap();
+        assert_eq!(array![[[1, 2], [3, 4]], [[5, 6], [7, 8]]].into_dyn(), array);
+    }
+
+    #[test]
+    fn build_array_from_shape_3d_fortran() {
+        let data = [1, 2, 3, 4, 5, 6, 7, 8];
+        let shape = vec![2, 2, 2].into_shape().f();
+        let array = build_array_from_shape(shape, &data).unwrap();
+        assert_eq!(array![[[1, 5], [3, 7]], [[2, 6], [4, 8]]].into_dyn(), array);
+    }
+
+    #[test]
+    fn build_array_from_shape_err() {
+        let data = [1, 2, 3];
+        let shape = vec![4].into_shape();
+        match build_array_from_shape(shape, &data) {
+            Err(err) => {
+                assert_eq!(ndarray::ErrorKind::OutOfBounds, err.kind())
+            }
+            _ => panic!("Expected out of bounds error"),
+        }
+    }
+
+    #[test]
+    fn build_slice_info_1d_no_selection() {
+        let selection = None;
+        let shape = [1];
+        let slice_info = build_slice_info::<u32>(&selection, &shape).unwrap();
+        assert_eq!(
+            [ndarray::SliceInfoElem::Slice {
+                start: 0,
+                end: None,
+                step: 1
+            }],
+            slice_info.as_ref()
+        );
+    }
+
+    #[test]
+    fn build_slice_info_1d_selection() {
+        let selection = Some(vec![models::Slice::new(0, 1, 1)]);
+        let shape = [];
+        let slice_info = build_slice_info::<u32>(&selection, &shape).unwrap();
+        assert_eq!(
+            [ndarray::SliceInfoElem::Slice {
+                start: 0,
+                end: Some(1),
+                step: 1
+            }],
+            slice_info.as_ref()
+        );
+    }
+
+    #[test]
+    fn build_slice_info_2d_no_selection() {
+        let selection = None;
+        let shape = [1, 2];
+        let slice_info = build_slice_info::<u32>(&selection, &shape).unwrap();
+        assert_eq!(
+            [
+                ndarray::SliceInfoElem::Slice {
+                    start: 0,
+                    end: None,
+                    step: 1
+                },
+                ndarray::SliceInfoElem::Slice {
+                    start: 0,
+                    end: None,
+                    step: 1
+                }
+            ],
+            slice_info.as_ref()
+        );
+    }
+
+    #[test]
+    fn build_slice_info_2d_selection() {
+        let selection = Some(vec![
+            models::Slice::new(0, 1, 1),
+            models::Slice::new(0, 1, 1),
+        ]);
+        let shape = [];
+        let slice_info = build_slice_info::<u32>(&selection, &shape).unwrap();
+        assert_eq!(
+            [
+                ndarray::SliceInfoElem::Slice {
+                    start: 0,
+                    end: Some(1),
+                    step: 1
+                },
+                ndarray::SliceInfoElem::Slice {
+                    start: 0,
+                    end: Some(1),
+                    step: 1
+                }
+            ],
+            slice_info.as_ref()
+        );
+    }
+
+    #[test]
+    fn build_array_1d_u32() {
+        let data = [1, 2, 3, 4, 5, 6, 7, 8];
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Uint32,
+            offset: None,
+            size: None,
+            shape: None,
+            order: None,
+            selection: None,
+        };
+        let bytes = Bytes::copy_from_slice(&data);
+        let array = build_array::<u32>(&request_data, &bytes);
+        assert_eq!(array![0x04030201_u32, 0x08070605_u32].into_dyn(), array);
+    }
+
+    #[test]
+    fn build_array_2d_i64() {
+        let data = [1, 2, 3, 4, 0, 0, 0, 0, 5, 6, 7, 8, 0, 0, 0, 0];
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Int64,
+            offset: None,
+            size: None,
+            shape: Some(vec![2, 1]),
+            order: None,
+            selection: None,
+        };
+        let bytes = Bytes::copy_from_slice(&data);
+        let array = build_array::<i64>(&request_data, &bytes);
+        assert_eq!(array![[0x04030201_i64], [0x08070605_i64]].into_dyn(), array);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use tokio::signal;
 
 mod app;
+mod array;
 mod models;
 mod s3_client;
 mod validated_json;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod app;
 mod array;
 mod models;
 mod operation;
+mod operations;
 mod s3_client;
 mod validated_json;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use tokio::signal;
 mod app;
 mod array;
 mod models;
+mod operation;
 mod s3_client;
 mod validated_json;
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,3 +1,4 @@
+use axum::body::Bytes;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 use url::Url;
@@ -126,18 +127,14 @@ fn validate_request_data(request_data: &RequestData) -> Result<(), ValidationErr
 
 /// Response containing the result of a computation and associated metadata.
 pub struct Response {
-    pub result: String,
+    pub body: Bytes,
     pub dtype: DType,
     pub shape: Vec<usize>,
 }
 
 impl Response {
-    pub fn new(result: String, dtype: DType, shape: Vec<usize>) -> Response {
-        Response {
-            result,
-            dtype,
-            shape,
-        }
+    pub fn new(body: Bytes, dtype: DType, shape: Vec<usize>) -> Response {
+        Response { body, dtype, shape }
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -46,6 +46,14 @@ pub struct Slice {
     pub stride: usize,
 }
 
+impl Slice {
+    /// Return a new Slice object.
+    #[allow(dead_code)]
+    pub fn new(start: usize, end: usize, stride: usize) -> Self {
+        Slice { start, end, stride }
+    }
+}
+
 #[derive(Debug, Deserialize, PartialEq, Validate)]
 #[serde(deny_unknown_fields)]
 #[validate(schema(function = "validate_request_data"))]
@@ -162,18 +170,7 @@ mod tests {
             size: Some(8),
             shape: Some(vec![1, 2]),
             order: Some(Order::C),
-            selection: Some(vec![
-                Slice {
-                    start: 1,
-                    end: 2,
-                    stride: 3,
-                },
-                Slice {
-                    start: 4,
-                    end: 5,
-                    stride: 6,
-                },
-            ]),
+            selection: Some(vec![Slice::new(1, 2, 3), Slice::new(4, 5, 6)]),
         }
     }
 
@@ -430,11 +427,7 @@ mod tests {
     #[should_panic(expected = "stride must be greater than 0")]
     fn test_invalid_selection2() {
         let mut request_data = get_test_request_data();
-        request_data.selection = Some(vec![Slice {
-            start: 1,
-            end: 2,
-            stride: 0,
-        }]);
+        request_data.selection = Some(vec![Slice::new(1, 2, 0)]);
         request_data.validate().unwrap()
     }
 
@@ -442,11 +435,7 @@ mod tests {
     #[should_panic(expected = "Selection end must be greater than start")]
     fn test_invalid_selection3() {
         let mut request_data = get_test_request_data();
-        request_data.selection = Some(vec![Slice {
-            start: 1,
-            end: 1,
-            stride: 1,
-        }]);
+        request_data.selection = Some(vec![Slice::new(1, 1, 1)]);
         request_data.validate().unwrap()
     }
 
@@ -463,11 +452,7 @@ mod tests {
     fn test_shape_selection_mismatch() {
         let mut request_data = get_test_request_data();
         request_data.shape = Some(vec![1, 2]);
-        request_data.selection = Some(vec![Slice {
-            start: 1,
-            end: 2,
-            stride: 1,
-        }]);
+        request_data.selection = Some(vec![Slice::new(1, 2, 1)]);
         request_data.validate().unwrap()
     }
 
@@ -475,11 +460,7 @@ mod tests {
     #[should_panic(expected = "Selection requires shape to be specified")]
     fn test_selection_without_shape() {
         let mut request_data = get_test_request_data();
-        request_data.selection = Some(vec![Slice {
-            start: 1,
-            end: 2,
-            stride: 1,
-        }]);
+        request_data.selection = Some(vec![Slice::new(1, 2, 1)]);
         request_data.validate().unwrap()
     }
     #[test]

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -116,8 +116,8 @@ mod tests {
             _data: &Bytes,
         ) -> models::Response {
             // Write the name of the type parameter to the body.
-            let body = std::any::type_name::<T>().to_string();
-            models::Response::new(body, request_data.dtype, vec![1, 2])
+            let body = std::any::type_name::<T>();
+            models::Response::new(body.into(), request_data.dtype, vec![1, 2])
         }
     }
 
@@ -137,7 +137,7 @@ mod tests {
         let data = [1, 2, 3, 4];
         let bytes = Bytes::copy_from_slice(&data);
         let response = TestNumOp::execute(&request_data, &bytes);
-        assert_eq!("i64".to_string(), response.result);
+        assert_eq!("i64", response.body);
         assert_eq!(models::DType::Int64, response.dtype);
         assert_eq!(vec![1, 2], response.shape);
     }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -1,0 +1,144 @@
+use crate::models;
+
+use axum::body::Bytes;
+
+/// Trait for array elements.
+pub trait Element:
+    Clone
+    + Copy
+    + PartialOrd
+    + num_traits::FromPrimitive
+    + num_traits::Zero
+    + std::fmt::Debug
+    + std::ops::Add<Output = Self>
+    + std::ops::Div<Output = Self>
+    + zerocopy::AsBytes
+    + zerocopy::FromBytes
+{
+}
+
+/// Blanket implementation of Element.
+impl<T> Element for T where
+    T: Clone
+        + Copy
+        + PartialOrd
+        + num_traits::FromPrimitive
+        + num_traits::One
+        + num_traits::Zero
+        + std::fmt::Debug
+        + std::ops::Add<Output = Self>
+        + std::ops::Div<Output = Self>
+        + zerocopy::AsBytes
+        + zerocopy::FromBytes
+{
+}
+
+/// Trait for active storage operations.
+///
+/// This forms the contract between the API layer and operations.
+pub trait Operation {
+    /// Execute the operation.
+    ///
+    /// Returns a [models::Response](crate::models::Response) object with response data.
+    ///
+    /// # Arguments
+    ///
+    /// * `request_data`: RequestData object for the request
+    /// * `data`: Bytes containing data to operate on.
+    fn execute(request_data: &models::RequestData, data: &Bytes) -> models::Response;
+}
+
+/// Trait for active storage operations on numerical data.
+///
+/// This trait provides an entry point into the type system based on the runtime `dtype` value.
+pub trait NumOperation: Operation {
+    fn execute_t<T: Element>(request_data: &models::RequestData, data: &Bytes) -> models::Response;
+}
+
+impl<T: NumOperation> Operation for T {
+    /// Execute the operation.
+    ///
+    /// This method dispatches to `execute_t` based on the `dtype`.
+    fn execute(request_data: &models::RequestData, data: &Bytes) -> models::Response {
+        // Convert runtime data type into concrete types.
+        match request_data.dtype {
+            models::DType::Int32 => Self::execute_t::<i32>(request_data, data),
+            models::DType::Int64 => Self::execute_t::<i64>(request_data, data),
+            models::DType::Uint32 => Self::execute_t::<u32>(request_data, data),
+            models::DType::Uint64 => Self::execute_t::<u64>(request_data, data),
+            models::DType::Float32 => Self::execute_t::<f32>(request_data, data),
+            models::DType::Float64 => Self::execute_t::<f64>(request_data, data),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use url::Url;
+
+    struct TestOp {}
+
+    impl Operation for TestOp {
+        fn execute(request_data: &models::RequestData, data: &Bytes) -> models::Response {
+            // Clone request body into response body.
+            models::Response::new(data.clone(), request_data.dtype, vec![3])
+        }
+    }
+
+    #[test]
+    fn operation_u32() {
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Uint32,
+            offset: None,
+            size: None,
+            shape: None,
+            order: None,
+            selection: None,
+        };
+        let data = [1, 2, 3, 4];
+        let bytes = Bytes::copy_from_slice(&data);
+        let response = TestOp::execute(&request_data, &bytes);
+        assert_eq!(&[1, 2, 3, 4][..], response.body);
+        assert_eq!(models::DType::Uint32, response.dtype);
+        assert_eq!(vec![3], response.shape);
+    }
+
+    struct TestNumOp {}
+
+    impl NumOperation for TestNumOp {
+        fn execute_t<T: Element>(
+            request_data: &models::RequestData,
+            _data: &Bytes,
+        ) -> models::Response {
+            // Write the name of the type parameter to the body.
+            let body = std::any::type_name::<T>().to_string();
+            models::Response::new(body, request_data.dtype, vec![1, 2])
+        }
+    }
+
+    #[test]
+    fn num_operation_i64() {
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Int64,
+            offset: None,
+            size: None,
+            shape: None,
+            order: None,
+            selection: None,
+        };
+        let data = [1, 2, 3, 4];
+        let bytes = Bytes::copy_from_slice(&data);
+        let response = TestNumOp::execute(&request_data, &bytes);
+        assert_eq!("i64".to_string(), response.result);
+        assert_eq!(models::DType::Int64, response.dtype);
+        assert_eq!(vec![1, 2], response.shape);
+    }
+}

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -1,0 +1,325 @@
+//! Numerical operations.
+//!
+//! Each operation is implemented as a struct that implements the
+//! [Operation](crate::operation::Operation) trait.
+
+use crate::array;
+use crate::models;
+use crate::operation::{Element, NumOperation};
+
+use axum::body::Bytes;
+use ndarray_stats::QuantileExt;
+// Bring trait into scope to use as_bytes method.
+use zerocopy::AsBytes;
+
+/// Return the number of selected elements in the array.
+pub struct Count {}
+
+impl NumOperation for Count {
+    fn execute_t<T: Element>(request_data: &models::RequestData, data: &Bytes) -> models::Response {
+        let array = array::build_array::<T>(request_data, data);
+        let slice_info = array::build_slice_info::<T>(&request_data.selection, array.shape());
+        let sliced = array.slice(slice_info.unwrap());
+        // FIXME: endianness?
+        // FIXME: handle errors
+        let len = i64::try_from(sliced.len()).unwrap();
+        let body = len.to_le_bytes();
+        // Need to copy to provide ownership to caller.
+        let body = Bytes::copy_from_slice(&body);
+        models::Response::new(body, models::DType::Int64, vec![])
+    }
+}
+
+/// Return the maximum of selected elements in the array.
+pub struct Max {}
+
+impl NumOperation for Max {
+    fn execute_t<T: Element>(request_data: &models::RequestData, data: &Bytes) -> models::Response {
+        let array = array::build_array::<T>(request_data, data);
+        let slice_info = array::build_slice_info::<T>(&request_data.selection, array.shape());
+        let sliced = array.slice(slice_info.unwrap());
+        // FIXME: endianness?
+        // FIXME: handle errors
+        let body = sliced.max().unwrap().as_bytes();
+        // Need to copy to provide ownership to caller.
+        let body = Bytes::copy_from_slice(body);
+        models::Response::new(body, request_data.dtype, vec![])
+    }
+}
+
+/// Return the mean of selected elements in the array.
+pub struct Mean {}
+
+impl NumOperation for Mean {
+    fn execute_t<T: Element>(request_data: &models::RequestData, data: &Bytes) -> models::Response {
+        let array = array::build_array::<T>(request_data, data);
+        let slice_info = array::build_slice_info::<T>(&request_data.selection, array.shape());
+        let sliced = array.slice(slice_info.unwrap());
+        // FIXME: endianness?
+        // FIXME: handle errors
+        let body = sliced.mean().unwrap();
+        let body = body.as_bytes();
+        // Need to copy to provide ownership to caller.
+        let body = Bytes::copy_from_slice(body);
+        models::Response::new(body, request_data.dtype, vec![])
+    }
+}
+
+/// Return the minimum of selected elements in the array.
+pub struct Min {}
+
+impl NumOperation for Min {
+    fn execute_t<T: Element>(request_data: &models::RequestData, data: &Bytes) -> models::Response {
+        let array = array::build_array::<T>(request_data, data);
+        let slice_info = array::build_slice_info::<T>(&request_data.selection, array.shape());
+        let sliced = array.slice(slice_info.unwrap());
+        // FIXME: endianness?
+        // FIXME: handle errors
+        let body = sliced.min().unwrap().as_bytes();
+        // Need to copy to provide ownership to caller.
+        let body = Bytes::copy_from_slice(body);
+        models::Response::new(body, request_data.dtype, vec![])
+    }
+}
+
+/// Return all selected elements in the array.
+pub struct Select {}
+
+impl NumOperation for Select {
+    fn execute_t<T: Element>(request_data: &models::RequestData, data: &Bytes) -> models::Response {
+        let array = array::build_array::<T>(request_data, data);
+        let slice_info = array::build_slice_info::<T>(&request_data.selection, array.shape());
+        let sliced = array.slice(slice_info.unwrap());
+        let shape = sliced.shape().to_vec();
+        // Transpose Fortran ordered arrays before iterating.
+        let body = if !array.is_standard_layout() {
+            let sliced_ordered = sliced.t();
+            // FIXME: endianness?
+            sliced_ordered.iter().copied().collect::<Vec<T>>()
+        } else {
+            // FIXME: endianness?
+            sliced.iter().copied().collect::<Vec<T>>()
+        };
+        let body = body.as_bytes();
+        // Need to copy to provide ownership to caller.
+        let body = Bytes::copy_from_slice(body);
+        models::Response::new(body, request_data.dtype, shape)
+    }
+}
+
+/// Return the sum of selected elements in the array.
+pub struct Sum {}
+
+impl NumOperation for Sum {
+    fn execute_t<T: Element>(request_data: &models::RequestData, data: &Bytes) -> models::Response {
+        let array = array::build_array::<T>(request_data, data);
+        let slice_info = array::build_slice_info::<T>(&request_data.selection, array.shape());
+        let sliced = array.slice(slice_info.unwrap());
+        // FIXME: endianness?
+        let body = sliced.sum();
+        let body = body.as_bytes();
+        // Need to copy to provide ownership to caller.
+        let body = Bytes::copy_from_slice(body);
+        models::Response::new(body, request_data.dtype, vec![])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::operation::Operation;
+
+    use url::Url;
+
+    #[test]
+    fn count_i32_1d() {
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Int32,
+            offset: None,
+            size: None,
+            shape: None,
+            order: None,
+            selection: None,
+        };
+        let data = [1, 2, 3, 4, 5, 6, 7, 8];
+        let bytes = Bytes::copy_from_slice(&data);
+        let response = Count::execute(&request_data, &bytes);
+        // Count is always i64.
+        let expected: i64 = 2;
+        assert_eq!(expected.as_bytes(), response.body);
+        assert_eq!(8, response.body.len());
+        assert_eq!(models::DType::Int64, response.dtype);
+        assert_eq!(vec![0; 0], response.shape);
+    }
+
+    #[test]
+    fn max_i64_1d() {
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Int64,
+            offset: None,
+            size: None,
+            shape: None,
+            order: None,
+            selection: None,
+        };
+        let data = [1, 2, 3, 4, 5, 6, 7, 8];
+        let bytes = Bytes::copy_from_slice(&data);
+        let response = Max::execute(&request_data, &bytes);
+        let expected: i64 = 0x0807060504030201;
+        assert_eq!(expected.as_bytes(), response.body);
+        assert_eq!(8, response.body.len());
+        assert_eq!(models::DType::Int64, response.dtype);
+        assert_eq!(vec![0; 0], response.shape);
+    }
+
+    #[test]
+    fn mean_u32_1d() {
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Uint32,
+            offset: None,
+            size: None,
+            shape: None,
+            order: None,
+            selection: None,
+        };
+        let data = [1, 2, 3, 4, 5, 6, 7, 8];
+        let bytes = Bytes::copy_from_slice(&data);
+        let response = Mean::execute(&request_data, &bytes);
+        let expected: i32 = (0x08070605 + 0x04030201) / 2;
+        assert_eq!(expected.as_bytes(), response.body);
+        assert_eq!(4, response.body.len());
+        assert_eq!(models::DType::Uint32, response.dtype);
+        assert_eq!(vec![0; 0], response.shape);
+    }
+
+    #[test]
+    fn min_u64_1d() {
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Uint64,
+            offset: None,
+            size: None,
+            shape: None,
+            order: None,
+            selection: None,
+        };
+        let data = [1, 2, 3, 4, 5, 6, 7, 8];
+        let bytes = Bytes::copy_from_slice(&data);
+        let response = Min::execute(&request_data, &bytes);
+        let expected: u64 = 0x0807060504030201;
+        assert_eq!(expected.as_bytes(), response.body);
+        assert_eq!(8, response.body.len());
+        assert_eq!(models::DType::Uint64, response.dtype);
+        assert_eq!(vec![0; 0], response.shape);
+    }
+
+    #[test]
+    fn select_f32_1d() {
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Float32,
+            offset: None,
+            size: None,
+            shape: None,
+            order: None,
+            selection: None,
+        };
+        let data = [1, 2, 3, 4, 5, 6, 7, 8];
+        let bytes = Bytes::copy_from_slice(&data);
+        let response = Select::execute(&request_data, &bytes);
+        let expected: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+        assert_eq!(expected.as_bytes(), response.body);
+        assert_eq!(8, response.body.len());
+        assert_eq!(models::DType::Float32, response.dtype);
+        assert_eq!(vec![2], response.shape);
+    }
+
+    #[test]
+    fn select_f64_2d() {
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Float64,
+            offset: None,
+            size: None,
+            shape: Some(vec![2, 1]),
+            order: None,
+            selection: None,
+        };
+        let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let bytes = Bytes::copy_from_slice(&data);
+        let response = Select::execute(&request_data, &bytes);
+        let expected: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        assert_eq!(expected.as_bytes(), response.body);
+        assert_eq!(16, response.body.len());
+        assert_eq!(models::DType::Float64, response.dtype);
+        assert_eq!(vec![2, 1], response.shape);
+    }
+
+    #[test]
+    fn select_f32_2d_with_selection() {
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Float32,
+            offset: None,
+            size: None,
+            shape: Some(vec![2, 2]),
+            order: None,
+            selection: Some(vec![
+                models::Slice::new(0, 2, 1),
+                models::Slice::new(1, 2, 1),
+            ]),
+        };
+        // 2x2 array, select second row of each column.
+        // [[0x04030201, 0x08070605], [0x12111009, 0x16151413]]
+        let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        let bytes = Bytes::copy_from_slice(&data);
+        let response = Select::execute(&request_data, &bytes);
+        // [[0x08070605], [0x16151413]]
+        let expected: [u8; 8] = [5, 6, 7, 8, 13, 14, 15, 16];
+        assert_eq!(expected.as_bytes(), response.body);
+        assert_eq!(8, response.body.len());
+        assert_eq!(models::DType::Float32, response.dtype);
+        assert_eq!(vec![2, 1], response.shape);
+    }
+
+    #[test]
+    fn sum_u32_1d() {
+        let request_data = models::RequestData {
+            source: Url::parse("http://example.com").unwrap(),
+            bucket: "bar".to_string(),
+            object: "baz".to_string(),
+            dtype: models::DType::Uint32,
+            offset: None,
+            size: None,
+            shape: None,
+            order: None,
+            selection: None,
+        };
+        let data = [1, 2, 3, 4, 5, 6, 7, 8];
+        let bytes = Bytes::copy_from_slice(&data);
+        let response = Sum::execute(&request_data, &bytes);
+        let expected: u32 = 0x04030201 + 0x08070605;
+        assert_eq!(expected.as_bytes(), response.body);
+        assert_eq!(4, response.body.len());
+        assert_eq!(models::DType::Uint32, response.dtype);
+        assert_eq!(vec![0; 0], response.shape);
+    }
+}

--- a/src/s3_client.rs
+++ b/src/s3_client.rs
@@ -1,6 +1,5 @@
 /// This module provides a simplified S3 client that supports downloading objects.
 /// It attempts to hide the complexities of working with the AWS SDK for S3.
-use aws_config::{self, meta::region::RegionProviderChain};
 use aws_credential_types::Credentials;
 use aws_sdk_s3::Client;
 use aws_types::region::Region;
@@ -23,10 +22,10 @@ impl S3Client {
     /// * `password`: Object storage account password
     pub async fn new(url: &Url, username: &str, password: &str) -> Self {
         let credentials = Credentials::from_keys(username, password, None);
-        let region = RegionProviderChain::default_provider().or_else(Region::new("us-east-1"));
-        let config = aws_config::from_env().region(region).load().await;
-        let s3_config = aws_sdk_s3::config::Builder::from(&config)
+        let region = Region::new("us-east-1");
+        let s3_config = aws_sdk_s3::Config::builder() //&config)
             .credentials_provider(credentials)
+            .region(Some(region))
             .endpoint_url(url.to_string())
             .force_path_style(true)
             .build();

--- a/src/s3_client.rs
+++ b/src/s3_client.rs
@@ -86,7 +86,6 @@ impl S3Client {
 ///
 /// * `offset`: Optional offset of data in bytes
 /// * `size`: Optional size of data in bytes
-#[allow(dead_code)]
 pub fn get_range(offset: Option<usize>, size: Option<usize>) -> Option<String> {
     match (offset, size) {
         (offset, Some(size)) => {


### PR DESCRIPTION
- request_data: Add validation of shape indices > 0
- s3_client: Add byte range support
- Switch to usize for size, offset, shape & selection
- Add Slice constructor
- Add array module
- Add operation module
- s3_client: Stop using aws_config
- validated_json: Include error sources in formatted error
- Response: switch to Bytes for body
- Add numerical operations module
