### PR TITLE
Reduce copying of data in S3 client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "1.0"
 tokio = { version = "1.24", features = ["full"] }
 tower = "0.4"
 tower-http = { version = "0.3", features = ["normalize-path", "trace", "validate-request"] }
+tokio-stream = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ thiserror = "1.0"
 tokio = { version = "1.24", features = ["full"] }
 tower = "0.4"
 tower-http = { version = "0.3", features = ["normalize-path", "trace", "validate-request"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
 zerocopy = { version = "0.6.1", features = ["alloc", "simd"] }

--- a/scripts/upload_sample_data.py
+++ b/scripts/upload_sample_data.py
@@ -3,6 +3,9 @@ import numpy as np
 import pathlib
 import s3fs
 
+NUM_ITEMS = 10
+OBJECT_PREFIX = "data"
+
 #Use enum which also subclasses string type so that 
 # auto-generated OpenAPI schema can determine allowed dtypes
 class AllowedDatatypes(str, Enum):
@@ -32,7 +35,7 @@ except FileExistsError:
 
 # Create numpy arrays and upload to S3 as bytes
 for d in AllowedDatatypes.__members__.keys():
-    with s3_fs.open(bucket / f'data-{d}.dat', 'wb') as s3_file:
-        s3_file.write(np.arange(10, dtype=d).tobytes())
+    with s3_fs.open(bucket / f'{OBJECT_PREFIX}-{d}.dat', 'wb') as s3_file:
+        s3_file.write(np.arange(NUM_ITEMS, dtype=d).tobytes())
 
 print("Data upload successful. \nBucket contents:\n", s3_fs.ls(bucket))

--- a/src/error.rs
+++ b/src/error.rs
@@ -177,7 +177,6 @@ impl From<ActiveStorageError> for ErrorResponse {
             | ActiveStorageError::S3ByteStream(_) => Self::internal_server_error(&error),
 
             ActiveStorageError::S3GetObject(sdk_error) => {
-                // FIXME: we lose "error retrieving object from S3 storage"
                 // Tailor the response based on the specific SdkError variant.
                 match &sdk_error {
                     // These are generic SdkError variants.
@@ -190,12 +189,6 @@ impl From<ActiveStorageError> for ErrorResponse {
                     // This is a more specific ServiceError variant, with GetObjectError as the
                     // inner error.
                     SdkError::ServiceError(get_obj_error) => {
-                        //let error = if let Some(get_obj_message) = get_obj_error.err().message() {
-                        //    // FIXME: use message() & code()?
-                        //    &get_obj_error.err()
-                        //} else {
-                        //    &sdk_error
-                        //};
                         let get_obj_error = get_obj_error.err();
                         match get_obj_error.kind {
                             GetObjectErrorKind::InvalidObjectState(_)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use tokio::signal;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 mod app;
 mod array;
@@ -11,6 +12,8 @@ mod validated_json;
 
 #[tokio::main]
 async fn main() {
+    init_tracing();
+
     let router = app::router();
 
     // run it with hyper on localhost:8080
@@ -19,6 +22,16 @@ async fn main() {
         .with_graceful_shutdown(shutdown_signal())
         .await
         .unwrap();
+}
+
+fn init_tracing() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "s3_active_storage=debug,tower_http=debug".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
 }
 
 async fn shutdown_signal() {


### PR DESCRIPTION
- error: Remove stale FIXMEs
- Initialise tracing (logging)
- s3_client: Remove one unnecessary copy of data
- upload_data.py: Allow to more easily create larger objects
