### PR TITLE
Add basic CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
 zerocopy = { version = "0.6.1", features = ["alloc", "simd"] }
+clap = { version = "4.2.1", features = ["derive", "env"] }
 
 [dev-dependencies]
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ aws-smithy-http = "0.54"
 aws-smithy-types = "0.54"
 aws-types = "0.54"
 axum = { version = "0.6", features = ["headers"] }
+clap = { version = "4.2.1", features = ["derive", "env"] }
 http = "*"
 hyper = { version = "0.14", features = ["full"] }
 maligned = "0.2.1"
@@ -35,7 +36,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = { version = "2", features = ["serde"] }
 validator = { version = "0.16", features = ["derive"] }
 zerocopy = { version = "0.6.1", features = ["alloc", "simd"] }
-clap = { version = "4.2.1", features = ["derive", "env"] }
 
 [dev-dependencies]
 regex = "1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,8 +40,8 @@ mod validated_json;
 struct CommandLineArgs {
     #[arg(long, default_value = "0.0.0.0", env = "S3_ACTIVE_STORAGE_HOST")]
     host: String,
-    #[arg(long, default_value = "8080", env = "S3_ACTIVE_STORAGE_PORT")]
-    port: String,
+    #[arg(long, default_value = 8080, env = "S3_ACTIVE_STORAGE_PORT")]
+    port: u16,
 }
 
 /// Application entry point

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,8 +38,10 @@ mod validated_json;
 /// S3 Active Storage Proxy command line interface
 #[derive(Debug, Parser)]
 struct CommandLineArgs {
+    /// The IP address on which the proxy should listen
     #[arg(long, default_value = "0.0.0.0", env = "S3_ACTIVE_STORAGE_HOST")]
     host: String,
+    /// The port to which the proxy should bind
     #[arg(long, default_value_t = 8080, env = "S3_ACTIVE_STORAGE_PORT")]
     port: u16,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ mod validated_json;
 struct CommandLineArgs {
     #[arg(long, default_value = "0.0.0.0", env = "S3_ACTIVE_STORAGE_HOST")]
     host: String,
-    #[arg(long, default_value = 8080, env = "S3_ACTIVE_STORAGE_PORT")]
+    #[arg(long, default_value_t = 8080, env = "S3_ACTIVE_STORAGE_PORT")]
     port: u16,
 }
 


### PR DESCRIPTION
Currently supports host and port args (which can also be set by `S3_ACTIVE_STORAGE_{HOST,PORT}` env vars. Is it worth adding some kind of `--debug` flag for setting log level instead of falling back to `RUST_LOG`?