### PR TITLE
Feature/count header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@
 
 # Others
 scripts/venv
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Dev TLS certs
 .certs/
+
+# Others
+scripts/venv

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,7 +1578,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "s3-active-storage"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "aws-credential-types",

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ with a JSON payload of the form:
 
 The currently supported reducers are `max`, `min`, `mean`, `sum`, `select` and `count`. All reducers return the result using the same datatype as specified in the request except for `count` which always returns the result as `int64`.
 
-The proxy adds two custom headers `x-activestorage-dtype` and `x-activestrorage-shape` to the HTTP response to allow the numeric result to be reconstructed from the binary content of the response.
+The proxy adds two custom headers `x-activestorage-dtype` and `x-activestrorage-shape` to the HTTP response to allow the numeric result to be reconstructed from the binary content of the response. An additional `x-activestorage-count` header is also returned which contains the number of array elements operated on while performing the requested reduction. This header is useful, for example, to calculate the mean over multiple requests where the number of items operated on may differ between chunks.
 
 [//]: <> (TODO: No OpenAPI support yet).
 [//]: <> (For a running instance of the proxy server, the full OpenAPI specification is browsable as a web page at the `{proxy-address}/redoc/` endpoint or in raw JSON form at `{proxy-address}/openapi.json`.)

--- a/scripts/client.py
+++ b/scripts/client.py
@@ -36,6 +36,7 @@ def get_args() -> argparse.Namespace:
     parser.add_argument("--shape", type=str)
     parser.add_argument("--order", default="C") #, choices=["C", "F"]) allow invalid for testing
     parser.add_argument("--selection", type=str)
+    parser.add_argument("--show-response-headers", action=argparse.BooleanOptionalAction)
     return parser.parse_args()
 
 
@@ -65,13 +66,17 @@ def request(url: str, username: str, password: str, request_data: dict):
     return response
 
 
-def display(response):
+def display(response, show_headers=False):
     #print(response.content)
     dtype = response.headers['x-activestorage-dtype']
     shape = json.loads(response.headers['x-activestorage-shape'])
     result = np.frombuffer(response.content, dtype=dtype)
     result = result.reshape(shape)
-    print(result)
+    if show_headers:
+        print("\nResponse headers:", response.headers)
+        print("\nResult:", result)
+    else:
+        print(result)
 
 
 def display_error(response):
@@ -88,7 +93,7 @@ def main():
     url = f'{args.server}/v1/{args.operation}/'
     response = request(url, args.username, args.password, request_data)
     if response.ok:
-        display(response)
+        display(response, show_headers=args.show_response_headers)
     else:
         display_error(response)
         sys.exit(1)

--- a/src/app.rs
+++ b/src/app.rs
@@ -29,6 +29,8 @@ use tower_http::validate_request::ValidateRequestHeaderLayer;
 static HEADER_DTYPE: header::HeaderName = header::HeaderName::from_static("x-activestorage-dtype");
 /// `x-activestorage-shape` header definition
 static HEADER_SHAPE: header::HeaderName = header::HeaderName::from_static("x-activestorage-shape");
+/// `x-activestorage-count` header definition
+static HEADER_COUNT: header::HeaderName = header::HeaderName::from_static("x-activestorage-count");
 
 impl IntoResponse for models::Response {
     /// Convert a [crate::models::Response] into a [axum::response::Response].
@@ -41,6 +43,7 @@ impl IntoResponse for models::Response {
                 ),
                 (&HEADER_DTYPE, self.dtype.to_string().to_lowercase()),
                 (&HEADER_SHAPE, serde_json::to_string(&self.shape).unwrap()),
+                (&HEADER_COUNT, serde_json::to_string(&self.count).unwrap()),
             ],
             self.body,
         )

--- a/src/models.rs
+++ b/src/models.rs
@@ -186,12 +186,19 @@ pub struct Response {
     pub dtype: DType,
     /// Shape of the response
     pub shape: Vec<usize>,
+    /// Number of non-missing elements operated on to generate response
+    pub count: i64,
 }
 
 impl Response {
     /// Return a Response object
-    pub fn new(body: Bytes, dtype: DType, shape: Vec<usize>) -> Response {
-        Response { body, dtype, shape }
+    pub fn new(body: Bytes, dtype: DType, shape: Vec<usize>, count: i64) -> Response {
+        Response {
+            body,
+            dtype,
+            shape,
+            count,
+        }
     }
 }
 

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -102,6 +102,7 @@ mod tests {
                 data.clone(),
                 request_data.dtype,
                 vec![3],
+                3,
             ))
         }
     }
@@ -125,6 +126,7 @@ mod tests {
         assert_eq!(&[1, 2, 3, 4][..], response.body);
         assert_eq!(models::DType::Uint32, response.dtype);
         assert_eq!(vec![3], response.shape);
+        assert_eq!(3, response.count);
     }
 
     struct TestNumOp {}
@@ -140,6 +142,7 @@ mod tests {
                 body.into(),
                 request_data.dtype,
                 vec![1, 2],
+                2,
             ))
         }
     }
@@ -163,5 +166,6 @@ mod tests {
         assert_eq!("i64", response.body);
         assert_eq!(models::DType::Int64, response.dtype);
         assert_eq!(vec![1, 2], response.shape);
+        assert_eq!(2, response.count);
     }
 }

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -174,13 +174,14 @@ mod tests {
             order: None,
             selection: None,
         };
-        let data = [1, 2, 3, 4, 5, 6, 7, 8];
+        let data: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
         let bytes = Bytes::copy_from_slice(&data);
         let response = Count::execute(&request_data, &bytes).unwrap();
+        // A u8 slice of 8 elements == a u32 slice with 2 elements
         // Count is always i64.
         let expected: i64 = 2;
         assert_eq!(expected.as_bytes(), response.body);
-        assert_eq!(8, response.body.len());
+        assert_eq!(8, response.body.len()); // Assert that count value is 8 bytes (i.e. i64)
         assert_eq!(models::DType::Int64, response.dtype);
         assert_eq!(vec![0; 0], response.shape);
     }
@@ -198,7 +199,12 @@ mod tests {
             order: None,
             selection: None,
         };
-        let data = [1, 2, 3, 4, 5, 6, 7, 8];
+        // data:
+        // A u8 slice of 8 elements == a single i64 value
+        // where each slice element is 2 hexadecimal digits
+        // and the order is reversed on little-endian systems
+        // so [1, 2, 3] is 0x030201 as an i64 in hexadecimal
+        let data: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
         let bytes = Bytes::copy_from_slice(&data);
         let response = Max::execute(&request_data, &bytes).unwrap();
         let expected: i64 = 0x0807060504030201;

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -10,7 +10,6 @@ use crate::operation::{Element, NumOperation};
 
 use axum::body::Bytes;
 use ndarray_stats::{errors::MinMaxError, QuantileExt};
-use num_traits::ToPrimitive;
 // Bring trait into scope to use as_bytes method.
 use zerocopy::AsBytes;
 
@@ -53,10 +52,7 @@ impl NumOperation for Max {
         let slice_info = array::build_slice_info::<T>(&request_data.selection, array.shape());
         let sliced = array.slice(slice_info);
         // FIXME: Account for missing data?
-        let count = sliced
-            .len()
-            .to_i64()
-            .expect("Count to be convertible to i64");
+        let count = i64::try_from(sliced.len())?;
         // FIXME: endianness?
         let body = sliced
             .max()
@@ -88,10 +84,7 @@ impl NumOperation for Mean {
         let slice_info = array::build_slice_info::<T>(&request_data.selection, array.shape());
         let sliced = array.slice(slice_info);
         // FIXME: Account for missing data?
-        let count = sliced
-            .len()
-            .to_i64()
-            .expect("Count to be convertible to i64");
+        let count = i64::try_from(sliced.len())?;
         // FIXME: endianness?
         let body = sliced
             .mean()
@@ -120,10 +113,7 @@ impl NumOperation for Min {
         let slice_info = array::build_slice_info::<T>(&request_data.selection, array.shape());
         let sliced = array.slice(slice_info);
         // FIXME: Account for missing data?
-        let count = sliced
-            .len()
-            .to_i64()
-            .expect("Count to be convertible to i64");
+        let count = i64::try_from(sliced.len())?;
         // FIXME: endianness?
         let body = sliced
             .min()
@@ -155,10 +145,7 @@ impl NumOperation for Select {
         let slice_info = array::build_slice_info::<T>(&request_data.selection, array.shape());
         let sliced = array.slice(slice_info);
         // FIXME: Account for missing data?
-        let count = sliced
-            .len()
-            .to_i64()
-            .expect("Count to be convertible to i64");
+        let count = i64::try_from(sliced.len())?;
         let shape = sliced.shape().to_vec();
         // Transpose Fortran ordered arrays before iterating.
         let body = if !array.is_standard_layout() {
@@ -193,10 +180,7 @@ impl NumOperation for Sum {
         let slice_info = array::build_slice_info::<T>(&request_data.selection, array.shape());
         let sliced = array.slice(slice_info);
         // FIXME: Account for missing data?
-        let count = sliced
-            .len()
-            .to_i64()
-            .expect("Count to be convertible to i64");
+        let count = i64::try_from(sliced.len())?;
         // FIXME: endianness?
         let body = sliced.sum();
         let body = body.as_bytes();

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -13,8 +13,6 @@ use ndarray_stats::{errors::MinMaxError, QuantileExt};
 // Bring trait into scope to use as_bytes method.
 use zerocopy::AsBytes;
 
-// TODO: Remove count method from API once count-as-response-header is implemented
-
 /// Return the number of selected elements in the array.
 pub struct Count {}
 


### PR DESCRIPTION
Adds an extra HTTP header to all successful responses with a count of the number of elements operated on while calculating the result of reduction. 

This probably makes the `count` endpoint obsolete and worth removing. I can remove that endpoint as part of this PR and bump semver to `0.2.0` if that's the route we want to take.