### PR TITLE
API schema endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -662,6 +662,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+
+[[package]]
 name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1598,6 +1604,7 @@ dependencies = [
  "ndarray-stats",
  "num-traits",
  "regex",
+ "schemars",
  "serde",
  "serde_json",
  "serde_test",
@@ -1622,6 +1629,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "schemars"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+dependencies = [
+ "bytes",
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1687,6 +1720,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bf8229e7920a9f636479437026331ce11aa132b4dde37d121944a44d6e5f3c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,7 +1578,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "s3-active-storage"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "aws-credential-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ ndarray-stats = "0.5"
 num-traits = "0.2.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "*"
+schemars = { version = "0.8.11", features = ["url", "bytes"] }
 strum_macros = "0.24"
 thiserror = "1.0"
 tokio = { version = "1.28", features = ["full"] }

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,13 +1,14 @@
 //! Data types and associated functions and methods
 
 use axum::body::Bytes;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use strum_macros::Display;
 use url::Url;
 use validator::{Validate, ValidationError};
 
 /// Supported numerical data types
-#[derive(Clone, Copy, Debug, Deserialize, Display, PartialEq)]
+#[derive(Clone, Copy, Debug, Deserialize, Display, PartialEq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum DType {
     /// [i32]
@@ -41,7 +42,7 @@ impl DType {
 /// Array ordering
 ///
 /// Defines an ordering for multi-dimensional arrays.
-#[derive(Debug, Deserialize, PartialEq)]
+#[derive(Debug, Deserialize, PartialEq, JsonSchema)]
 pub enum Order {
     /// Row-major (C) ordering
     C,
@@ -65,7 +66,7 @@ pub enum Order {
 /// * positive_end <= i < positive_start
 // NOTE: In serde, structs can be deserialised from sequences or maps. This allows us to support
 // the [<start>, <end>, <stride>] API, with the convenience of named fields.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, Validate)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize, Validate, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[validate(schema(function = "validate_slice"))]
 pub struct Slice {
@@ -86,7 +87,7 @@ impl Slice {
 }
 
 /// Request data for operations
-#[derive(Debug, Deserialize, PartialEq, Validate)]
+#[derive(Debug, Deserialize, PartialEq, Validate, JsonSchema)]
 #[serde(deny_unknown_fields)]
 #[validate(schema(function = "validate_request_data"))]
 pub struct RequestData {
@@ -179,6 +180,7 @@ fn validate_request_data(request_data: &RequestData) -> Result<(), ValidationErr
 }
 
 /// Response containing the result of a computation and associated metadata.
+#[derive(JsonSchema)]
 pub struct Response {
     /// Response data. May be a scalar or multi-dimensional array.
     pub body: Bytes,


### PR DESCRIPTION
It looks like integrating [aide](https://docs.rs/aide/0.10.0/aide/index.html) with our existing code to generate a proper OpenAPI schema is going to be a little difficult (more trait bound issues which I think stem from our custom `models::Response` implementation). I will continue looking into this but in the mean time, this PR adds two endpoints which return simple JSON schema to at least provide some form of live documentation.