### PR TITLE
Refactor into a library with a minimal binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1578,7 +1578,7 @@ checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "s3-active-storage"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "aws-credential-types",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,35 @@
+//! This crate provides an Active Storage Server. It implements simple reductions on S3 objects
+//! containing numeric binary data.  By implementing these reductions in the storage system the
+//! volume of data that needs to be transferred to the end user is vastly reduced, leading to
+//! faster computations.
+//!
+//! The work is funded by the
+//! [ExCALIBUR project](https://www.metoffice.gov.uk/research/approach/collaboration/spf/excalibur)
+//! and is done in collaboration with the
+//! [University of Reading](http://www.reading.ac.uk/).
+//!
+//! This is a performant implementation of the Active Storage Server.
+//! The original Python functional prototype is available
+//! [here](https://github.com/stackhpc/s3-active-storage).
+//!
+//! The Active Storage Server is built on top of a number of open source components.
+//!
+//! * [Tokio](tokio), the most popular asynchronous Rust runtime.
+//! * [Axum](axum) web framework, built by the Tokio team. Axum performs well in [various](https://github.com/programatik29/rust-web-benchmarks/blob/master/result/hello-world.md) [benchmarks](https://web-frameworks-benchmark.netlify.app/result?l=rust)
+//!   and is built on top of various popular components, including the [hyper] HTTP library.
+//! * [Serde](serde) performs (de)serialisation of JSON request and response data.
+//! * [AWS SDK for S3](aws-sdk-s3) is used to interact with S3-compatible object stores.
+//! * [ndarray] provides [NumPy](https://numpy.orgq)-like n-dimensional arrays used in numerical
+//!   computation.
+
+pub mod app;
+pub mod array;
+pub mod cli;
+pub mod error;
+pub mod models;
+pub mod operation;
+pub mod operations;
+pub mod s3_client;
+pub mod server;
+pub mod tracing;
+pub mod validated_json;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,38 +1,9 @@
-//! This crate provides an Active Storage Server. It implements simple reductions on S3 objects
-//! containing numeric binary data.  By implementing these reductions in the storage system the
-//! volume of data that needs to be transferred to the end user is vastly reduced, leading to
-//! faster computations.
-//!
-//! The work is funded by the
-//! [ExCALIBUR project](https://www.metoffice.gov.uk/research/approach/collaboration/spf/excalibur)
-//! and is done in collaboration with the
-//! [University of Reading](http://www.reading.ac.uk/).
-//!
-//! This is a performant implementation of the Active Storage Server.
-//! The original Python functional prototype is available
-//! [here](https://github.com/stackhpc/s3-active-storage).
-//!
-//! The Active Storage Server is built on top of a number of open source components.
-//!
-//! * [Tokio](tokio), the most popular asynchronous Rust runtime.
-//! * [Axum](axum) web framework, built by the Tokio team. Axum performs well in [various](https://github.com/programatik29/rust-web-benchmarks/blob/master/result/hello-world.md) [benchmarks](https://web-frameworks-benchmark.netlify.app/result?l=rust)
-//!   and is built on top of various popular components, including the [hyper] HTTP library.
-//! * [Serde](serde) performs (de)serialisation of JSON request and response data.
-//! * [AWS SDK for S3](aws-sdk-s3) is used to interact with S3-compatible object stores.
-//! * [ndarray] provides [NumPy](https://numpy.orgq)-like n-dimensional arrays used in numerical
-//!   computation.
+//! This file defines the s3-active-storage binary entry point.
 
-mod app;
-mod array;
-mod cli;
-mod error;
-mod models;
-mod operation;
-mod operations;
-mod s3_client;
-mod server;
-mod tracing;
-mod validated_json;
+use s3_active_storage::app;
+use s3_active_storage::cli;
+use s3_active_storage::server;
+use s3_active_storage::tracing;
 
 /// Application entry point
 #[tokio::main]


### PR DESCRIPTION
This change refactors the code from a binary project into a library.
The main.rs file is now an included binary that uses the
s3_active_storage library.

This opens up the potential for extension by building a different crate
that uses this crate, and adds or modifies its behaviour.
