### PR TITLE
CI: Only run dependency review on pull requests

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -93,6 +93,7 @@ jobs:
         if: always()
   dependency-review:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
It fails when run on push.
