### PR TITLE
Refactor tests to use utilities to build RequestData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -95,13 +95,13 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -382,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.18"
+version = "0.6.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
+checksum = "a6a1de45611fdb535bfde7b7de4fd54f4fd2b17b1737c0a59b69bf9b92074b8c"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -452,15 +452,15 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.6.2",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
 ]
@@ -561,9 +561,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.3.9"
+version = "4.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bba77a07e4489fb41bd90e8d4201c3eb246b3c2c9ea2ba0bddd6c1d1df87db7d"
+checksum = "74bb1b4028935821b2d6b439bba2e970bdcf740832732437ead910c632e30d7d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -572,27 +572,26 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.9"
+version = "4.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9b4a88bb4bc35d3d6f65a21b0f0bafe9c894fa00978de242c555ec28bea1c0"
+checksum = "5ae467cbb0111869b765e13882a1dbbd6cb52f58203d8b80c44f667d4dd19843"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags 1.3.2",
  "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -631,9 +630,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -751,7 +750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.1",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -904,18 +903,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -1052,20 +1042,19 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
- "rustix 0.37.19",
+ "hermit-abi",
+ "rustix 0.38.4",
  "windows-sys 0.48.0",
 ]
 
@@ -1080,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
@@ -1113,9 +1102,9 @@ checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
@@ -1145,7 +1134,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1184,15 +1173,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -1291,19 +1271,19 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.30.4"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "memchr",
 ]
@@ -1352,7 +1332,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.3.5",
  "smallvec",
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -1363,29 +1343,29 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95a7476719eab1e366eaf73d0260af3021184f18177925b07f54b30089ceead"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.0"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -1425,9 +1405,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -1442,7 +1422,7 @@ dependencies = [
  "byteorder",
  "hex",
  "lazy_static",
- "rustix 0.36.14",
+ "rustix 0.36.15",
 ]
 
 [[package]]
@@ -1480,9 +1460,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "5fe8a65d69dd0808184ebb5f836ab526bb259db23c657efa38711b1072ee47f0"
 dependencies = [
  "proc-macro2",
 ]
@@ -1551,13 +1531,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.2",
+ "regex-automata 0.3.3",
+ "regex-syntax 0.7.4",
 ]
 
 [[package]]
@@ -1570,6 +1551,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.7.4",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,9 +1569,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "ring"
@@ -1625,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.36.14"
+version = "0.36.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14e4d67015953998ad0eb82887a0eb0129e18a7e2f3b7b0f6c422fddcd503d62"
+checksum = "c37f1bd5ef1b5422177b7646cba67430579cfe2ace80f284fee876bca52ad941"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -1639,15 +1631,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
- "linux-raw-sys 0.3.8",
+ "linux-raw-sys 0.4.3",
  "windows-sys 0.48.0",
 ]
 
@@ -1677,24 +1668,24 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64 0.21.2",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "s3-active-storage"
@@ -1739,18 +1730,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
- "windows-sys 0.42.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -1787,35 +1778,35 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1824,18 +1815,19 @@ dependencies = [
 
 [[package]]
 name = "serde_path_to_error"
-version = "0.1.11"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f05c1d5476066defcdfacce1f52fc3cae3af1d3089727100c02ae92e5abbe0"
+checksum = "4beec8bce849d58d06238cb50db2e1c417cfeafa4c63f692b15c82b7c80f8335"
 dependencies = [
+ "itoa",
  "serde",
 ]
 
 [[package]]
 name = "serde_test"
-version = "1.0.164"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797c38160e2546a56e1e3439496439597e938669673ffd8af02a12f070da648f"
+checksum = "b6480a2f4e1449ec9757ea143362ad5cea79bc7f1cb7711c06e1c5d03b6b5a3a"
 dependencies = [
  "serde",
 ]
@@ -1903,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -1961,9 +1953,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1978,22 +1970,22 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -2008,9 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "serde",
  "time-core",
@@ -2025,9 +2017,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
 dependencies = [
  "time-core",
 ]
@@ -2049,9 +2041,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.29.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374442f06ee49c3a28a8fc9f01a2596fed7559c6b99b31279c3261778e77d84f"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
  "backtrace",
@@ -2075,7 +2067,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -2132,9 +2124,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8bd22a874a2d0b70452d5597b12c537331d49060824a95f49f108994f94aa4c"
+checksum = "7ac8060a61f8758a61562f6fb53ba3cbe1ca906f001df2e53cccddcdbee91e7c"
 dependencies = [
  "bitflags 2.3.3",
  "bytes",
@@ -2183,7 +2175,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
 ]
 
 [[package]]
@@ -2245,9 +2237,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -2384,7 +2376,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
  "wasm-bindgen-shared",
 ]
 
@@ -2406,7 +2398,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.26",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2461,21 +2453,6 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
@@ -2489,7 +2466,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
+ "windows-targets 0.48.1",
 ]
 
 [[package]]
@@ -2509,9 +2486,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm 0.48.0",
  "windows_aarch64_msvc 0.48.0",

--- a/src/array.rs
+++ b/src/array.rs
@@ -148,8 +148,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    use url::Url;
+    use crate::test_utils;
 
     #[test]
     fn from_bytes_u32() {
@@ -224,41 +223,15 @@ mod tests {
 
     #[test]
     fn get_shape_without_shape() {
-        let shape = get_shape(
-            42,
-            &models::RequestData {
-                source: Url::parse("http://example.com").unwrap(),
-                bucket: "bar".to_string(),
-                object: "baz".to_string(),
-                dtype: models::DType::Int32,
-                offset: None,
-                size: None,
-                shape: None,
-                order: None,
-                selection: None,
-                compression: None,
-            },
-        );
+        let shape = get_shape(42, &test_utils::get_test_request_data());
         assert_eq!([42], shape.raw_dim().as_array_view().as_slice().unwrap());
     }
 
     #[test]
     fn get_shape_with_shape() {
-        let shape = get_shape(
-            42,
-            &models::RequestData {
-                source: Url::parse("http://example.com").unwrap(),
-                bucket: "bar".to_string(),
-                object: "baz".to_string(),
-                dtype: models::DType::Int32,
-                offset: None,
-                size: None,
-                shape: Some(vec![1, 2, 3]),
-                order: None,
-                selection: None,
-                compression: None,
-            },
-        );
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.shape = Some(vec![1, 2, 3]);
+        let shape = get_shape(42, &request_data);
         assert_eq!(
             [1, 2, 3],
             shape.raw_dim().as_array_view().as_slice().unwrap()
@@ -450,18 +423,8 @@ mod tests {
     #[test]
     fn build_array_1d_u32() {
         let data = [1, 2, 3, 4, 5, 6, 7, 8];
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Uint32,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Uint32;
         let bytes = Bytes::copy_from_slice(&data);
         let array = build_array::<u32>(&request_data, &bytes).unwrap();
         assert_eq!(array![0x04030201_u32, 0x08070605_u32].into_dyn(), array);
@@ -470,18 +433,9 @@ mod tests {
     #[test]
     fn build_array_2d_i64() {
         let data = [1, 2, 3, 4, 0, 0, 0, 0, 5, 6, 7, 8, 0, 0, 0, 0];
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Int64,
-            offset: None,
-            size: None,
-            shape: Some(vec![2, 1]),
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Int64;
+        request_data.shape = Some(vec![2, 1]);
         let bytes = Bytes::copy_from_slice(&data);
         let array = build_array::<i64>(&request_data, &bytes).unwrap();
         assert_eq!(array![[0x04030201_i64], [0x08070605_i64]].into_dyn(), array);
@@ -490,18 +444,8 @@ mod tests {
     // Helper function for tests that slice an array using a selection.
     fn test_selection(slice: models::Slice, expected: Array1<u32>) {
         let data = [1, 2, 3, 4, 5, 6, 7, 8];
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Uint32,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Uint32;
         let bytes = Bytes::copy_from_slice(&data);
         let array = build_array::<u32>(&request_data, &bytes).unwrap();
         let shape = vec![2];

--- a/src/filter_pipeline.rs
+++ b/src/filter_pipeline.rs
@@ -29,10 +29,10 @@ pub fn filter_pipeline(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils;
     use flate2::read::GzEncoder;
     use flate2::Compression;
     use std::io::Read;
-    use url::Url;
 
     fn compress_gzip(data: &[u8]) -> Bytes {
         // Adapated from flate2 documentation.
@@ -46,18 +46,7 @@ mod tests {
     fn test_filter_pipeline_noop() {
         let data = [1, 2, 3, 4];
         let bytes = Bytes::copy_from_slice(&data);
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Int32,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let request_data = test_utils::get_test_request_data();
         let result = filter_pipeline(&request_data, &bytes).unwrap();
         assert_eq!(data.as_ref(), result);
     }
@@ -66,18 +55,8 @@ mod tests {
     fn test_filter_pipeline_gzip() {
         let data = [1, 2, 3, 4];
         let bytes = compress_gzip(data.as_ref());
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Int32,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: Some(models::Compression::Gzip),
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.compression = Some(models::Compression::Gzip);
         let result = filter_pipeline(&request_data, &bytes).unwrap();
         assert_eq!(data.as_ref(), result);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,5 +34,7 @@ pub mod operation;
 pub mod operations;
 pub mod s3_client;
 pub mod server;
+#[cfg(test)]
+pub mod test_utils;
 pub mod tracing;
 pub mod validated_json;

--- a/src/models.rs
+++ b/src/models.rs
@@ -249,44 +249,15 @@ impl Response {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils;
     use serde_test::{assert_de_tokens, assert_de_tokens_error, Token};
-
-    fn get_test_request_data() -> RequestData {
-        RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: DType::Int32,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        }
-    }
-
-    fn get_test_request_data_optional() -> RequestData {
-        RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: DType::Int32,
-            offset: Some(4),
-            size: Some(8),
-            shape: Some(vec![2, 5]),
-            order: Some(Order::C),
-            selection: Some(vec![Slice::new(1, 2, 3), Slice::new(4, 5, 6)]),
-            compression: Some(Compression::Gzip),
-        }
-    }
 
     // The following tests use serde_test to validate the correct function of the deserialiser.
     // The validations are also tested.
 
     #[test]
     fn test_required_fields() {
-        let request_data = get_test_request_data();
+        let request_data = test_utils::get_test_request_data();
         assert_de_tokens(
             &request_data,
             &[
@@ -312,7 +283,7 @@ mod tests {
 
     #[test]
     fn test_optional_fields() {
-        let request_data = get_test_request_data_optional();
+        let request_data = test_utils::get_test_request_data_optional();
         assert_de_tokens(
             &request_data,
             &[
@@ -422,7 +393,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "bucket must not be empty")]
     fn test_invalid_bucket() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.bucket = "".to_string();
         request_data.validate().unwrap()
     }
@@ -448,7 +419,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "object must not be empty")]
     fn test_invalid_object() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.object = "".to_string();
         request_data.validate().unwrap()
     }
@@ -489,7 +460,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "size must be greater than 0")]
     fn test_invalid_size() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.size = Some(0);
         request_data.validate().unwrap()
     }
@@ -497,7 +468,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "shape length must be greater than 0")]
     fn test_invalid_shape() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.shape = Some(vec![]);
         request_data.validate().unwrap()
     }
@@ -505,7 +476,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "shape indices must be greater than 0")]
     fn test_invalid_shape_indices() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.shape = Some(vec![0]);
         request_data.validate().unwrap()
     }
@@ -531,7 +502,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "selection length must be greater than 0")]
     fn test_invalid_selection() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.selection = Some(vec![]);
         request_data.validate().unwrap()
     }
@@ -539,7 +510,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Selection stride must not be equal to zero")]
     fn test_invalid_selection2() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.selection = Some(vec![Slice::new(1, 2, 0)]);
         request_data.validate().unwrap()
     }
@@ -547,7 +518,7 @@ mod tests {
     #[test]
     fn test_selection_end_lt_start() {
         // Numpy sementics: start >= end yields an empty array
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.shape = Some(vec![1]);
         request_data.selection = Some(vec![Slice::new(1, 0, 1)]);
         request_data.validate().unwrap()
@@ -555,7 +526,7 @@ mod tests {
 
     #[test]
     fn test_selection_negative_stride() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.shape = Some(vec![1]);
         request_data.selection = Some(vec![Slice::new(1, 0, -1)]);
         request_data.validate().unwrap()
@@ -564,7 +535,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Raw data size must be a multiple of dtype size in bytes")]
     fn test_invalid_size_for_dtype() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.size = Some(1);
         request_data.validate().unwrap()
     }
@@ -574,7 +545,7 @@ mod tests {
         expected = "Raw data size must be equal to the product of shape indices and dtype size in bytes"
     )]
     fn test_invalid_size_for_shape() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.size = Some(4);
         request_data.shape = Some(vec![1, 2]);
         request_data.validate().unwrap()
@@ -583,7 +554,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Shape and selection must have the same length")]
     fn test_shape_selection_mismatch() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.shape = Some(vec![1, 2]);
         request_data.selection = Some(vec![Slice::new(1, 2, 1)]);
         request_data.validate().unwrap()
@@ -592,7 +563,7 @@ mod tests {
     #[test]
     fn test_selection_start_gt_shape() {
         // Numpy sementics: start > length yields an empty array
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.shape = Some(vec![4]);
         request_data.selection = Some(vec![Slice::new(5, 5, 1)]);
         request_data.validate().unwrap()
@@ -601,7 +572,7 @@ mod tests {
     #[test]
     fn test_selection_start_lt_negative_shape() {
         // Numpy sementics: start < -length gets clamped to zero
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.shape = Some(vec![4]);
         request_data.selection = Some(vec![Slice::new(-5, 5, 1)]);
         request_data.validate().unwrap()
@@ -610,7 +581,7 @@ mod tests {
     #[test]
     fn test_selection_end_gt_shape() {
         // Numpy semantics: end > length gets clamped to length
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.shape = Some(vec![4]);
         request_data.selection = Some(vec![Slice::new(1, 5, 1)]);
         request_data.validate().unwrap()
@@ -619,7 +590,7 @@ mod tests {
     #[test]
     fn test_selection_end_lt_negative_shape() {
         // Numpy semantics: end < -length gets clamped to zero
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.shape = Some(vec![4]);
         request_data.selection = Some(vec![Slice::new(1, -5, 1)]);
         request_data.validate().unwrap()
@@ -628,7 +599,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Selection requires shape to be specified")]
     fn test_selection_without_shape() {
-        let mut request_data = get_test_request_data();
+        let mut request_data = test_utils::get_test_request_data();
         request_data.selection = Some(vec![Slice::new(1, 2, 1)]);
         request_data.validate().unwrap()
     }
@@ -669,13 +640,13 @@ mod tests {
     fn test_json_required_fields() {
         let json = r#"{"source": "http://example.com", "bucket": "bar", "object": "baz", "dtype": "int32"}"#;
         let request_data = serde_json::from_str::<RequestData>(json).unwrap();
-        assert_eq!(request_data, get_test_request_data());
+        assert_eq!(request_data, test_utils::get_test_request_data());
     }
 
     #[test]
     fn test_json_optional_fields() {
         let json = r#"{"source": "http://example.com", "bucket": "bar", "object": "baz", "dtype": "int32", "offset": 4, "size": 8, "shape": [2, 5], "order": "C", "selection": [[1, 2, 3], [4, 5, 6]], "compression": {"id": "gzip"}}"#;
         let request_data = serde_json::from_str::<RequestData>(json).unwrap();
-        assert_eq!(request_data, get_test_request_data_optional());
+        assert_eq!(request_data, test_utils::get_test_request_data_optional());
     }
 }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -88,7 +88,7 @@ impl<T: NumOperation> Operation for T {
 mod tests {
     use super::*;
 
-    use url::Url;
+    use crate::test_utils;
 
     struct TestOp {}
 
@@ -109,18 +109,8 @@ mod tests {
 
     #[test]
     fn operation_u32() {
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Uint32,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Uint32;
         let data = [1, 2, 3, 4];
         let bytes = Bytes::copy_from_slice(&data);
         let response = TestOp::execute(&request_data, &bytes).unwrap();
@@ -150,18 +140,8 @@ mod tests {
 
     #[test]
     fn num_operation_i64() {
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Int64,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Int64;
         let data = [1, 2, 3, 4];
         let bytes = Bytes::copy_from_slice(&data);
         let response = TestNumOp::execute(&request_data, &bytes).unwrap();

--- a/src/operations.rs
+++ b/src/operations.rs
@@ -198,23 +198,11 @@ mod tests {
     use super::*;
 
     use crate::operation::Operation;
-
-    use url::Url;
+    use crate::test_utils;
 
     #[test]
     fn count_i32_1d() {
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Int32,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let request_data = test_utils::get_test_request_data();
         let data: [u8; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
         let bytes = Bytes::copy_from_slice(&data);
         let response = Count::execute(&request_data, &bytes).unwrap();
@@ -230,18 +218,8 @@ mod tests {
 
     #[test]
     fn max_i64_1d() {
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Int64,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Int64;
         // data:
         // A u8 slice of 8 elements == a single i64 value
         // where each slice element is 2 hexadecimal digits
@@ -260,18 +238,8 @@ mod tests {
 
     #[test]
     fn mean_u32_1d() {
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Uint32,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Uint32;
         let data = [1, 2, 3, 4, 5, 6, 7, 8];
         let bytes = Bytes::copy_from_slice(&data);
         let response = Mean::execute(&request_data, &bytes).unwrap();
@@ -285,18 +253,8 @@ mod tests {
 
     #[test]
     fn min_u64_1d() {
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Uint64,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Uint64;
         let data = [1, 2, 3, 4, 5, 6, 7, 8];
         let bytes = Bytes::copy_from_slice(&data);
         let response = Min::execute(&request_data, &bytes).unwrap();
@@ -310,18 +268,8 @@ mod tests {
 
     #[test]
     fn select_f32_1d() {
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Float32,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Float32;
         let data = [1, 2, 3, 4, 5, 6, 7, 8];
         let bytes = Bytes::copy_from_slice(&data);
         let response = Select::execute(&request_data, &bytes).unwrap();
@@ -335,18 +283,9 @@ mod tests {
 
     #[test]
     fn select_f64_2d() {
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Float64,
-            offset: None,
-            size: None,
-            shape: Some(vec![2, 1]),
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Float64;
+        request_data.shape = Some(vec![2, 1]);
         let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
         let bytes = Bytes::copy_from_slice(&data);
         let response = Select::execute(&request_data, &bytes).unwrap();
@@ -360,21 +299,13 @@ mod tests {
 
     #[test]
     fn select_f32_2d_with_selection() {
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Float32,
-            offset: None,
-            size: None,
-            shape: Some(vec![2, 2]),
-            order: None,
-            selection: Some(vec![
-                models::Slice::new(0, 2, 1),
-                models::Slice::new(1, 2, 1),
-            ]),
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Float32;
+        request_data.shape = Some(vec![2, 2]);
+        request_data.selection = Some(vec![
+            models::Slice::new(0, 2, 1),
+            models::Slice::new(1, 2, 1),
+        ]);
         // 2x2 array, select second row of each column.
         // [[0x04030201, 0x08070605], [0x12111009, 0x16151413]]
         let data = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
@@ -391,18 +322,8 @@ mod tests {
 
     #[test]
     fn sum_u32_1d() {
-        let request_data = models::RequestData {
-            source: Url::parse("http://example.com").unwrap(),
-            bucket: "bar".to_string(),
-            object: "baz".to_string(),
-            dtype: models::DType::Uint32,
-            offset: None,
-            size: None,
-            shape: None,
-            order: None,
-            selection: None,
-            compression: None,
-        };
+        let mut request_data = test_utils::get_test_request_data();
+        request_data.dtype = models::DType::Uint32;
         let data = [1, 2, 3, 4, 5, 6, 7, 8];
         let bytes = Bytes::copy_from_slice(&data);
         let response = Sum::execute(&request_data, &bytes).unwrap();

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,0 +1,35 @@
+use crate::models::*;
+
+use url::Url;
+
+/// Create a RequestData object with only required fields set.
+pub(crate) fn get_test_request_data() -> RequestData {
+    RequestData {
+        source: Url::parse("http://example.com").unwrap(),
+        bucket: "bar".to_string(),
+        object: "baz".to_string(),
+        dtype: DType::Int32,
+        offset: None,
+        size: None,
+        shape: None,
+        order: None,
+        selection: None,
+        compression: None,
+    }
+}
+
+/// Create a RequestData object with all fields set.
+pub(crate) fn get_test_request_data_optional() -> RequestData {
+    RequestData {
+        source: Url::parse("http://example.com").unwrap(),
+        bucket: "bar".to_string(),
+        object: "baz".to_string(),
+        dtype: DType::Int32,
+        offset: Some(4),
+        size: Some(8),
+        shape: Some(vec![2, 5]),
+        order: Some(Order::C),
+        selection: Some(vec![Slice::new(1, 2, 3), Slice::new(4, 5, 6)]),
+        compression: Some(Compression::Gzip),
+    }
+}


### PR DESCRIPTION
Adds a test_utils module which provides utilities for testing.
Move helper functions for building RequestData structs into the module.
Refactor tests to use the helpers.
