### PR TITLE
Remove /v1/mean endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ with a JSON payload of the form:
 }
 ```
 
-The currently supported reducers are `max`, `min`, `mean`, `sum`, `select` and `count`. All reducers return the result using the same datatype as specified in the request except for `count` which always returns the result as `int64`.
+The currently supported reducers are `max`, `min`, `sum`, `select` and `count`. All reducers return the result using the same datatype as specified in the request except for `count` which always returns the result as `int64`.
 
 The proxy adds two custom headers `x-activestorage-dtype` and `x-activestrorage-shape` to the HTTP response to allow the numeric result to be reconstructed from the binary content of the response. An additional `x-activestorage-count` header is also returned which contains the number of array elements operated on while performing the requested reduction. This header is useful, for example, to calculate the mean over multiple requests where the number of items operated on may differ between chunks.
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -66,7 +66,6 @@ fn router() -> Router {
         Router::new()
             .route("/count", post(operation_handler::<operations::Count>))
             .route("/max", post(operation_handler::<operations::Max>))
-            .route("/mean", post(operation_handler::<operations::Mean>))
             .route("/min", post(operation_handler::<operations::Min>))
             .route("/select", post(operation_handler::<operations::Select>))
             .route("/sum", post(operation_handler::<operations::Sum>))


### PR DESCRIPTION
The mean operation is not very useful since it cannot be used to take
a mean over several storage chunks. Instead it is necessary to use the
sum endpoint and take the count from the header.
