### PR TITLE
cargo lock version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,7 +1916,7 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "s3-active-storage"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "aws-credential-types",

--- a/scripts/minio-start
+++ b/scripts/minio-start
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-# Use anon storage volume so that test data is removed when container is stopped
-exec docker run --detach --rm -p 9000:9000 -p 9001:9001 -v :/data --name minio minio/minio server data --console-address ":9001"
+# Use timestamped storage volume so that test data is removed when container is stopped
+exec docker run --detach --rm -p 9000:9000 -p 9001:9001 -v minio_$(date +%s) --name minio minio/minio server data --console-address ":9001"


### PR DESCRIPTION
- Update version in Cargo.lock
- Fix minio-start for Docker 24.0
